### PR TITLE
Terrain and swimming

### DIFF
--- a/Assets/Animation/Player.controller
+++ b/Assets/Animation/Player.controller
@@ -95,6 +95,18 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -690005743340360816}
     m_Position: {x: 900, y: 1300, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1453409557843381265}
+    m_Position: {x: 935, y: 1365, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 933226167045335121}
+    m_Position: {x: 970, y: 1430, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1532972667598851080}
+    m_Position: {x: 1005, y: 1495, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3345338465810589458}
+    m_Position: {x: 1040, y: 1560, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -287,6 +299,32 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &-1453409557843381265
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_right
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 609a886415ca547b8a544b81c35d615b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &-1136585110264824280
 AnimatorState:
   serializedVersion: 6
@@ -439,6 +477,32 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &933226167045335121
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_left
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 8373b4478c4e34fcab4bcafd8883233e, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &1440749416731921646
 AnimatorState:
   serializedVersion: 6
@@ -465,6 +529,32 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &1532972667598851080
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_up
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cf7003ebbcd7b4511891f583ffbf2a5a, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &2415620847935262243
 AnimatorState:
   serializedVersion: 6
@@ -486,6 +576,32 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 1d8db711d5fca462282976f979cc8245, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &3345338465810589458
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_down
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f60c570173a8e4f908e65e9321b1fae0, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Assets/Animation/player_jump_down.anim
+++ b/Assets/Animation/player_jump_down.anim
@@ -122,7 +122,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animation/player_jump_left.anim
+++ b/Assets/Animation/player_jump_left.anim
@@ -122,7 +122,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animation/player_jump_right.anim
+++ b/Assets/Animation/player_jump_right.anim
@@ -122,7 +122,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animation/player_jump_up.anim
+++ b/Assets/Animation/player_jump_up.anim
@@ -122,7 +122,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animation/player_swim_down.anim
+++ b/Assets/Animation/player_swim_down.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_down
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 1548732387, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 1548732387, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/player_swim_down.anim.meta
+++ b/Assets/Animation/player_swim_down.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f60c570173a8e4f908e65e9321b1fae0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/player_swim_left.anim
+++ b/Assets/Animation/player_swim_left.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_left
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 909976830, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 909976830, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/player_swim_left.anim.meta
+++ b/Assets/Animation/player_swim_left.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8373b4478c4e34fcab4bcafd8883233e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/player_swim_right.anim
+++ b/Assets/Animation/player_swim_right.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_right
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -2058951926, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -2058951926, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/player_swim_right.anim.meta
+++ b/Assets/Animation/player_swim_right.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 609a886415ca547b8a544b81c35d615b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/player_swim_up.anim
+++ b/Assets/Animation/player_swim_up.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: player_swim_up
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -1286740012, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -1286740012, guid: fb47f4d5e7e8f462ab8b4fb056a1a5e6, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/player_swim_up.anim.meta
+++ b/Assets/Animation/player_swim_up.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf7003ebbcd7b4511891f583ffbf2a5a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayerInput.inputactions
+++ b/Assets/PlayerInput.inputactions
@@ -73,6 +73,17 @@
                     "isPartOfComposite": false
                 },
                 {
+                    "name": "",
+                    "id": "17ba496b-f7a2-4294-921d-3609279aa32f",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
                     "name": "WASD",
                     "id": "28b53c2a-4e9c-4868-8911-08498f1b622c",
                     "path": "Dpad",
@@ -518,6 +529,17 @@
                 },
                 {
                     "name": "",
+                    "id": "f7eaf99a-f748-4f63-b9f7-aa33b13bd4e1",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Read",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "c9c35199-9ed4-4e09-8ffc-826015ee97fa",
                     "path": "<Keyboard>/i",
                     "interactions": "",
@@ -529,8 +551,30 @@
                 },
                 {
                     "name": "",
+                    "id": "ba800217-f77e-4452-b025-456fc896cfe5",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Inventory",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "d5a9c5c3-d4d1-4c1b-a50c-76f2a38be217",
                     "path": "<Keyboard>/tab",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "14c06984-3a3d-46b4-8771-06d5ab5c9a6f",
+                    "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": "",

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -354,7 +354,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1adb6f0b8abf4e80b24a43750fbfd11, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _tilemap: {fileID: 0}
+  _heightMap: {fileID: 0}
+  _terrainMap: {fileID: 0}
   diagonals:
   - up-right
   - up-left
@@ -467,20 +468,28 @@ MonoBehaviour:
   Damaged: {fileID: 0}
   Dead: {fileID: 0}
   Jump: {fileID: 0}
+  Swim: {fileID: 0}
+  Fall: {fileID: 0}
   rb: {fileID: 0}
   col: {fileID: 0}
   moveVector: {x: 0, y: 0}
   runSpeed: 8
   walkSpeed: 5
+  swimSpeed: 4
+  fallSpeed: 8
+  jumpSpeed: 6
   idleVector: {x: 0, y: 0}
   facingDirection: {x: 0, y: 0}
   isJumping: 0
+  jumpDuration: 0.2
   jumpVector: {x: 0, y: 0}
   isShifting: 0
   animationState: {fileID: 0}
   z: 0
   tileDetector: {fileID: 0}
-  canWalk: 0
+  canMove: 0
+  canSwim: 0
+  onWall: 0
 --- !u!114 &3462501237082333913
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1198,6 +1198,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa9a6cba0d99e43d78927cbf7332a643, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1839735485 &1125717838 stripped
+Tilemap:
+  m_CorrespondingSourceObject: {fileID: 8303847178313254620, guid: a9d7ca20d71352f43afafbff4bf53030, type: 3}
+  m_PrefabInstance: {fileID: 914694440}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1142342002
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2309,6 +2314,14 @@ PrefabInstance:
       propertyPath: _tilemap
       value: 
       objectReference: {fileID: 1201864184}
+    - target: {fileID: 1855759994, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
+      propertyPath: _heightMap
+      value: 
+      objectReference: {fileID: 1201864184}
+    - target: {fileID: 1855759994, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
+      propertyPath: _terrainMap
+      value: 
+      objectReference: {fileID: 1125717838}
     - target: {fileID: 3462501237082333890, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -2352,6 +2365,10 @@ PrefabInstance:
     - target: {fileID: 3462501237082333890, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
+      propertyPath: swimSpeed
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333912, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2306,14 +2306,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 253151044, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1855759994, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
-      propertyPath: _tilemap
-      value: 
-      objectReference: {fileID: 1201864184}
     - target: {fileID: 1855759994, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: _heightMap
       value: 
@@ -2365,18 +2357,6 @@ PrefabInstance:
     - target: {fileID: 3462501237082333890, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
-      propertyPath: fallSpeed
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
-      propertyPath: swimSpeed
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
-      propertyPath: jumpDuration
-      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333912, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -824,7 +824,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -1317181961637108539, guid: a9d7ca20d71352f43afafbff4bf53030, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5088365187714604082, guid: a9d7ca20d71352f43afafbff4bf53030, type: 3}
       propertyPath: m_RootOrder
@@ -2367,8 +2367,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
+      propertyPath: fallSpeed
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: swimSpeed
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
+      propertyPath: jumpDuration
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333912, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2376,7 +2376,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333894, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: jumpDuration
-      value: 0.3
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 3462501237082333912, guid: 98b74bf4997774f22b5165692453c3aa, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -39,6 +39,7 @@ public class PlayerController : MonoBehaviour
     public float walkSpeed;
     public float swimSpeed;
     public float fallSpeed;
+    public float jumpSpeed;
     public Vector2 idleVector;
     public Vector2 facingDirection;
 
@@ -64,7 +65,7 @@ public class PlayerController : MonoBehaviour
 
     [Header("Tile Detector")]
     public TileDetector tileDetector;
-    public bool canWalk;
+    public bool canMove;
     public bool canSwim;
     public bool onWall;
     private Vector2 _adjacentTileDetectionPoint;
@@ -175,13 +176,6 @@ public class PlayerController : MonoBehaviour
         EnableMovement();
         SetCurrentZ();
 
-        if (canSwim)
-        {
-            // set as universal for now
-            // TODO:
-            SetState(Swim);
-        }
-
         currentState.UpdateState(this);
     }
 
@@ -189,8 +183,7 @@ public class PlayerController : MonoBehaviour
     {
         if (currentState == Walk || currentState == Run || currentState == Idle || currentState == Swim)
         {
-            // Debug < z?
-            if (GetCurrentZ() != z)
+            if (GetCurrentZ() < z)
             {
                 z = GetCurrentZ();
             }
@@ -292,14 +285,14 @@ public class PlayerController : MonoBehaviour
     //            if (height > z)
     //            {
     //                Debug.Log("high tile diagonal break");
-    //                canWalk = false;
+    //                canMove = false;
     //                break;
     //            }
     //        }
     //        else
     //        {
     //            Debug.Log("null tile diagonal break");
-    //            canWalk = false;
+    //            canMove = false;
     //            break;
     //        }
     //    }
@@ -322,7 +315,7 @@ public class PlayerController : MonoBehaviour
         {
             if (heightProp.m_Value.ToInt() > z)
             {
-                canWalk = false;
+                canMove = false;
             }
             // Creating an invisible collision when faced with a ledge.
             else if (heightProp.m_Value.ToInt() < z)
@@ -330,36 +323,31 @@ public class PlayerController : MonoBehaviour
                 // TODO: or Leap
                 if (currentState == Jump)
                 {
-                    canWalk = true;
+                    canMove = true;
                 }
                 else
                 {
-                    canWalk = false;
+                    canMove = false;
                 }
             }
             else // z is equal
             {
+                canMove = true;
                 // Wall handling
                 if (terrainProp != null)
                 {
                     if (terrainProp.m_Value == "wall" && currentState != Jump)
                     {
-                        canWalk = false;
-                    }
-                    else
-                    {
-                        canWalk = true;
+                        canMove = false;
                     }
                 }
-                else
-                {
-                    canWalk = true;
-                }
+
             }
         }
         else
         {
-            canWalk = false;
+            Debug.Log("height prop is null");
+            canMove = false;
         }
     }
 
@@ -401,7 +389,7 @@ public class PlayerController : MonoBehaviour
         //{
         //    if (heightProp.m_Value.ToInt() <= z)
         //    {
-        //        canWalk = true;
+        //        canMove = true;
         //    }
         //}
     }
@@ -417,7 +405,7 @@ public class PlayerController : MonoBehaviour
     //        if (heightProp.m_Value.ToInt() > z && !canSwim)
     //        {
     //            Debug.Log("yup");
-    //            canWalk = false;
+    //            canMove = false;
     //        }
     //        // Creating an invisible collision when faced with a ledge.
     //        else if (heightProp.m_Value.ToInt() < z)
@@ -425,21 +413,21 @@ public class PlayerController : MonoBehaviour
     //            // TODO: or Leap
     //            if (currentState == Jump)
     //            {
-    //                canWalk = true;
+    //                canMove = true;
     //            }
     //            else
     //            {
-    //                canWalk = false;
+    //                canMove = false;
     //            }
     //        }
     //        else
     //        {
-    //            canWalk = true;
+    //            canMove = true;
     //        }
     //    }
     //    else
     //    {
-    //        canWalk = false;
+    //        canMove = false;
     //    }
     //}
 

--- a/Assets/Scripts/States/Fall.cs
+++ b/Assets/Scripts/States/Fall.cs
@@ -20,7 +20,6 @@ public class Fall : State
 
     public override void StartState(PlayerController player)
     {
-        Debug.Log("fall ah");
         this._player = player;
     }
 

--- a/Assets/Scripts/States/Fall.cs
+++ b/Assets/Scripts/States/Fall.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Fall : State
+{
+    private PlayerController _player;
+
+    private Vector2 _fallVector = new(0f, -1f);
+
+    public override void FixedUpdateState(PlayerController player)
+    {
+        MovePlayer();
+    }
+
+    public override void LateUpdateState(PlayerController player)
+    {
+
+    }
+
+    public override void StartState(PlayerController player)
+    {
+        Debug.Log("fall ah");
+        this._player = player;
+    }
+
+    public override void UpdateState(PlayerController player)
+    {
+        if (!_player.onWall)
+        {
+            _player.SetState(_player.Idle);
+        }
+    }
+
+    private void MovePlayer()
+    {
+        _player.rb.velocity = _fallVector * _player.fallSpeed;
+    }
+}

--- a/Assets/Scripts/States/Fall.cs.meta
+++ b/Assets/Scripts/States/Fall.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 508af4956ee754194ac2d7ada417649b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/States/Idle.cs
+++ b/Assets/Scripts/States/Idle.cs
@@ -30,7 +30,10 @@ public class Idle : State
             _player.SetState(_player.Jump);
         }
 
-        //Animate();
+        if (_player.canSwim)
+        {
+            _player.SetState(_player.Swim);
+        }
     }
 
     public override void LateUpdateState(PlayerController player)

--- a/Assets/Scripts/States/Jump.cs
+++ b/Assets/Scripts/States/Jump.cs
@@ -17,7 +17,15 @@ public class Jump : State
         else
         {
             _player.isJumping = false;
-            _player.SetState(_player.Fall);
+            if (_player.canSwim)
+            {
+                _player.SetState(_player.Swim);
+            }
+            else
+            {
+                _player.SetState(_player.Fall);
+            }
+
         }
     }
 
@@ -43,9 +51,9 @@ public class Jump : State
 
     private void JumpPlayer()
     {
-        if (_player.canWalk)
+        if (_player.canMove)
         {
-            _player.rb.velocity = _player.walkSpeed * _player.moveVector;
+            _player.rb.velocity = _player.jumpSpeed * _player.moveVector;
         }
         else
         {

--- a/Assets/Scripts/States/Jump.cs
+++ b/Assets/Scripts/States/Jump.cs
@@ -17,7 +17,7 @@ public class Jump : State
         else
         {
             _player.isJumping = false;
-            _player.SetState(_player.Idle);
+            _player.SetState(_player.Fall);
         }
     }
 
@@ -76,7 +76,15 @@ public class Jump : State
     IEnumerator JumpSwitch()
     {
         _switch = true;
-        yield return new WaitForSeconds(.2f);
+        if (_player.facingDirection == Vector2.up || _player.facingDirection == Vector2.down)
+        {
+            yield return new WaitForSeconds(_player.jumpDuration + .1f);
+        }
+        else
+        {
+            yield return new WaitForSeconds(_player.jumpDuration);
+        }
+
         _switch = false;
     }
 }

--- a/Assets/Scripts/States/Run.cs
+++ b/Assets/Scripts/States/Run.cs
@@ -34,6 +34,11 @@ public class Run : State
         {
             _player.SetState(_player.Idle);
         }
+
+        if (_player.canSwim)
+        {
+            _player.SetState(_player.Swim);
+        }
     }
 
     public override void LateUpdateState(PlayerController player)
@@ -44,7 +49,7 @@ public class Run : State
     // TODO: DRY
     private void MovePlayer()
     {
-        if (_player.canWalk)
+        if (_player.canMove)
         {
             _player.rb.velocity = _player.runSpeed * _player.moveVector;
         }

--- a/Assets/Scripts/States/Swim.cs
+++ b/Assets/Scripts/States/Swim.cs
@@ -23,7 +23,13 @@ public class Swim : State
 
     public override void UpdateState(PlayerController player)
     {
-        // TODO:
+        if (!_player.canSwim)
+        {
+            if (_player.canWalk)
+            {
+                _player.SetState(_player.Walk);
+            }
+        }
     }
 
     private void MovePlayer()

--- a/Assets/Scripts/States/Swim.cs
+++ b/Assets/Scripts/States/Swim.cs
@@ -13,7 +13,7 @@ public class Swim : State
 
     public override void LateUpdateState(PlayerController player)
     {
-        // TODO:
+        Animate();
     }
 
     public override void StartState(PlayerController player)
@@ -34,8 +34,6 @@ public class Swim : State
 
     private void MovePlayer()
     {
-        Debug.Log("i'm swimming!");
-
         if (_player.canSwim)
         {
             _player.rb.velocity = _player.swimSpeed * _player.moveVector;
@@ -44,6 +42,26 @@ public class Swim : State
         else
         {
             _player.rb.velocity = Vector2.zero;
+        }
+    }
+
+    private void Animate()
+    {
+        if (_player.moveVector.x > 0f)
+        {
+            _player.animationState.SetAnimationState("player_swim_right");
+        }
+        else if (_player.moveVector.x < 0f)
+        {
+            _player.animationState.SetAnimationState("player_swim_left");
+        }
+        else if (_player.moveVector.x == 0f && _player.moveVector.y > 0f)
+        {
+            _player.animationState.SetAnimationState("player_swim_up");
+        }
+        else
+        {
+            _player.animationState.SetAnimationState("player_swim_down");
         }
     }
 }

--- a/Assets/Scripts/States/Swim.cs
+++ b/Assets/Scripts/States/Swim.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Swim : State
+{
+    private PlayerController _player;
+
+    public override void FixedUpdateState(PlayerController player)
+    {
+        MovePlayer();
+    }
+
+    public override void LateUpdateState(PlayerController player)
+    {
+        // TODO:
+    }
+
+    public override void StartState(PlayerController player)
+    {
+        this._player = player;
+    }
+
+    public override void UpdateState(PlayerController player)
+    {
+        // TODO:
+    }
+
+    private void MovePlayer()
+    {
+        Debug.Log("i'm swimming!");
+
+        if (_player.canSwim)
+        {
+            _player.rb.velocity = _player.swimSpeed * _player.moveVector;
+        }
+        // else stop movement?
+        else
+        {
+            _player.rb.velocity = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/States/Swim.cs
+++ b/Assets/Scripts/States/Swim.cs
@@ -25,7 +25,7 @@ public class Swim : State
     {
         if (!_player.canSwim)
         {
-            if (_player.canWalk)
+            if (_player.canMove)
             {
                 _player.SetState(_player.Walk);
             }

--- a/Assets/Scripts/States/Swim.cs.meta
+++ b/Assets/Scripts/States/Swim.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f17d4288b9974913a533c6284c366c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/States/Walk.cs
+++ b/Assets/Scripts/States/Walk.cs
@@ -6,7 +6,7 @@ using System;
 public class Walk : State
 {
     private PlayerController _player;
-    //private bool _canWalk;
+    //private bool _canMove;
     //private string _tileKey;
 
     public override void FixedUpdateState(PlayerController player)
@@ -38,6 +38,10 @@ public class Walk : State
         {
             _player.SetState(_player.Jump);
         }
+        else if (_player.canSwim)
+        {
+            _player.SetState(_player.Swim);
+        }
     }
 
     public override void LateUpdateState(PlayerController player)
@@ -48,7 +52,7 @@ public class Walk : State
     // TODO: DRY
     private void MovePlayer()
     {
-        if (_player.canWalk)
+        if (_player.canMove)
         {
             _player.rb.velocity = _player.walkSpeed * _player.moveVector;
         }
@@ -97,21 +101,21 @@ public class Walk : State
     //        {
     //            if (height <= _player.z)
     //            {
-    //                _canWalk = true;
+    //                _canMove = true;
     //            }
     //            else
     //            {
-    //                _canWalk = false;
+    //                _canMove = false;
     //            }
     //        }
     //        else
     //        {
-    //            _canWalk = true;
+    //            _canMove = true;
     //        }
     //    }
     //    else
     //    {
-    //        _canWalk = true;
+    //        _canMove = true;
     //    }
     //}
 

--- a/Assets/Scripts/TileDetector.cs
+++ b/Assets/Scripts/TileDetector.cs
@@ -9,7 +9,9 @@ public class TileDetector : MonoBehaviour
     [Header("Tilemap")]
     // Drag/assign in editor
     [SerializeField]
-    private Tilemap _tilemap;
+    private Tilemap _heightMap;
+    [SerializeField]
+    private Tilemap _terrainMap;
 
     public List<string> diagonals = new()
     {
@@ -20,7 +22,7 @@ public class TileDetector : MonoBehaviour
     };
 
     // TODO: this should be tiles? //List<CustomProperty>
-    private Dictionary<string, SuperTile> _tiles = new()
+    private Dictionary<string, SuperTile> _heightTiles = new()
     {
         { "current", null },
         { "left", null },
@@ -56,32 +58,26 @@ public class TileDetector : MonoBehaviour
     void DetectStandingTile()
     {
         // get the tile grid position from whereever this object is 
-        Vector3Int gridPosition = _tilemap.WorldToCell(transform.position);
+        Vector3Int heightMapGridPosition = _heightMap.WorldToCell(transform.position);
+        Vector3Int terrainMapGridPosition = _terrainMap.WorldToCell(transform.position);
 
-        if (_tilemap.HasTile(gridPosition))
+        if (_heightMap.HasTile(heightMapGridPosition))
         {
-            // set the current standing tile
-            // .m_CustomProperties
-            _tiles["current"] = _tilemap.GetTile<SuperTile>(gridPosition);
+            _heightTiles["current"] = _heightMap.GetTile<SuperTile>(heightMapGridPosition);
         }
         else
         {
-            // set the current standing tile
-            // TODO: should be an empty list?
-            _tiles["current"] = null;
+            _heightTiles["current"] = null;
         }
-
-
-        //Debug.Log(currentTile.m_CustomProperties[0].m_Name.ToString() + ": " + currentTile.m_CustomProperties[0].m_Value.ToString());
     }
 
     void DetectAdjacentTiles()
     {
         // initialize grid position
-        Vector3Int gridPosition = _tilemap.WorldToCell(transform.position);
+        Vector3Int gridPosition = _heightMap.WorldToCell(transform.position);
 
         // if there's no tile there for some reason, return
-        if (!_tilemap.HasTile(gridPosition))
+        if (!_heightMap.HasTile(gridPosition))
         {
             Debug.LogWarning($"No tile at position: {gridPosition}");
             return;
@@ -92,17 +88,17 @@ public class TileDetector : MonoBehaviour
         {
             Vector3Int position = gridPosition + adjacentPosition.Value;
 
-            // if there is a tile there, add it to _tiles
-            if (_tilemap.HasTile(position))
+            // if there is a tile there, add it to _heightTiles
+            if (_heightMap.HasTile(position))
             {
-                _tiles[adjacentPosition.Key] = _tilemap.GetTile<SuperTile>(position);
+                _heightTiles[adjacentPosition.Key] = _heightMap.GetTile<SuperTile>(position);
 
                 // Debug
-                //_tilemap.SetColor(position, Color.green);
+                //_heightMap.SetColor(position, Color.green);
             }
             else
             {
-                _tiles[adjacentPosition.Key] = null;
+                _heightTiles[adjacentPosition.Key] = null;
             }
         }
     }
@@ -115,7 +111,8 @@ public class TileDetector : MonoBehaviour
             return null;
         }
 
-        bool hasTileProps = _tiles.TryGetValue(tileKey, out SuperTile tile);
+        // TODO: swich based on propName
+        bool hasTileProps = _heightTiles.TryGetValue(tileKey, out SuperTile tile);
 
         if (hasTileProps && tile != null)
         {
@@ -149,27 +146,29 @@ public class TileDetector : MonoBehaviour
         return null;
     }
 
-    public SuperTile GetTile(Vector3 position)
+    // TODO: either add paramater or create different function
+    public SuperTile GetHeightTile(Vector3 position)
     {
         // get the tile grid position from whereever this object is
-        Vector3Int gridPosition = _tilemap.WorldToCell(position);
-        if (_tilemap.HasTile(gridPosition))
+        Vector3Int gridPosition = _heightMap.WorldToCell(position);
+        if (_heightMap.HasTile(gridPosition))
         {
-            return _tilemap.GetTile<SuperTile>(gridPosition);
+            return _heightMap.GetTile<SuperTile>(gridPosition);
         }
 
         return null;
     }
 
-    public SuperTile GetMappedTile(string tileKey)
+    public SuperTile GetTerrainTile(Vector3 position)
     {
-        _tiles.TryGetValue(tileKey, out SuperTile tile);
-
-        if (tile != null)
+        // get the tile grid position from whereever this object is
+        Vector3Int gridPosition = _terrainMap.WorldToCell(position);
+        if (_terrainMap.HasTile(gridPosition))
         {
-            return tile;
+            return _terrainMap.GetTile<SuperTile>(gridPosition);
         }
 
         return null;
     }
+
 }


### PR DESCRIPTION
PR checklist:

I double checked that in the Unity project (all must be checked before merge)
- [x] There are no console errors.
- [x] My test Scene(s) work as expected.
- [x] I did not push any changes to Scenes I do not own.

Note: this is just a first pass to get the functionality working, we will have many opportunities later to polish up

PR Description:
- the TileDetector has been tweaked to account for terrain map info.
- player can fall down "wall" terrain type now, rather than be able to jump onto those tiles.
- player can swim
- updated gamepad inputs for interacting, inventory and pause.

Trello ticket (Optional, but might provide good flavor for larger changes): 
